### PR TITLE
Fixes double HEAD tag inside BODY

### DIFF
--- a/editor/helper/dom.php
+++ b/editor/helper/dom.php
@@ -19,7 +19,7 @@ class Brizy_Editor_Helper_Dom extends Brizy_Editor_Helper_DomTag {
 	 */
 	public function get_body() {
 
-		$bodyPos    = strpos( $this->get_html(), "<body>" );
+		$bodyPos    = strpos( $this->get_html(), "<body" );
 		$bodyEndPos = strpos( $this->get_html(), "</body>" );
 		$bodyString = substr( $this->get_html(), $bodyPos, $bodyEndPos - $bodyPos + 7 );
 


### PR DESCRIPTION
The `get_body` function was updated not so long ago, from a regex to the current solution:

- https://github.com/ThemeFuse/Brizy/commit/4047c9249b6ca333c9015c527cc791cf5bca0c1c

The current solution doesn't select the `body` tag correctly, which causes the strpos being wrong and the `head` tag being inserted twice. Once where it should be, and once inside the body tag.

![](https://support.brizy.io/hc/user_images/_FOS7iIQeCMyDKWnG3rX-w.png)